### PR TITLE
Phase A: app coverage, internal links crawler, facilities-table filters, release_gate

### DIFF
--- a/locators/elements_for_new_web_site/for_app_page.py
+++ b/locators/elements_for_new_web_site/for_app_page.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from selenium.webdriver.common.by import By
+
+
+class AppPageLocators:
+    BASE_URL = "https://www.allsports.by/ru-by/app"
+
+    COOKIE_ACCEPT_BTN = (By.CSS_SELECTOR, ".cookie-primary-modal__confirm")
+    PAGE_ROOT = (By.CSS_SELECTOR, "main, #defaultView")
+    DOWNLOAD_HEADING = (By.XPATH, "//h2[contains(normalize-space(),'Скачать приложение Allsports')]")
+
+    APPLE_LINKS = (By.XPATH, "//a[contains(@href,'apps.apple.com')]")
+    GOOGLE_LINKS = (By.XPATH, "//a[contains(@href,'play.google.com')]")
+    HUAWEI_LINKS = (By.XPATH, "//a[contains(@href,'appgallery.huawei.com')]")
+
+    CANONICAL_LINK = (By.CSS_SELECTOR, "link[rel='canonical']")

--- a/locators/elements_for_new_web_site/for_facilities_page.py
+++ b/locators/elements_for_new_web_site/for_facilities_page.py
@@ -34,8 +34,10 @@ class FacilitiesLocators:
 
     # === FACILITIES TABLE PAGE ===
     TABLE_URL_SUFFIX = "/facilities-table"
+    TABLE_ROOT = (By.CSS_SELECTOR, ".facilities-table")
     TABLE_SEARCH_INPUT = (By.CSS_SELECTOR, "input[placeholder='Поиск']")
     TABLE_FILTER_BUTTON = (By.CSS_SELECTOR, "button.facilities-table-filter__button")
     TABLE_FILTER_MODAL = (By.CSS_SELECTOR, ".modal-container.map-filter-modal, .modal")
+    TABLE_FILTER_MODAL_ROOT = (By.CSS_SELECTOR, ".modal-container.map-filter-modal")
     TABLE_FILTER_APPLY = (By.XPATH, "//button[contains(.,'Применить')]")
     TABLE_FILTER_RESET = (By.XPATH, "//button[contains(.,'Сбросить фильтры')]")

--- a/pages/new_web_site/app_page.py
+++ b/pages/new_web_site/app_page.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+import time
+from urllib.parse import urlparse, urlunparse
+
+import allure
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+from helpers.base import BasePage
+from locators.elements_for_new_web_site.for_app_page import AppPageLocators as L
+
+
+class AppPage(BasePage):
+    @staticmethod
+    def _normalize_url(url: str) -> str:
+        parsed = urlparse(url)
+        path = parsed.path or "/"
+        if path != "/" and path.endswith("/"):
+            path = path[:-1]
+        return urlunparse((parsed.scheme, parsed.netloc.lower(), path, "", "", ""))
+
+    @staticmethod
+    def _filtered_console_errors(raw_logs):
+        severe = [entry for entry in raw_logs if entry.get("level") == "SEVERE"]
+        filtered = []
+        for entry in severe:
+            msg = (entry.get("message") or "").lower()
+            source = (entry.get("source") or "").lower()
+            if "sentry" in msg:
+                continue
+            if "content security policy" in msg or "csp" in msg:
+                continue
+            if source in ("security", "network"):
+                continue
+            filtered.append(entry)
+        return filtered
+
+    @allure.step("Открыть страницу App")
+    def open(self):
+        self.driver.get(L.BASE_URL)
+        WebDriverWait(self.driver, 20).until(
+            EC.presence_of_element_located(L.PAGE_ROOT)
+        )
+        return self
+
+    @allure.step("Принять cookies (если баннер есть)")
+    def accept_cookie_consent(self):
+        try:
+            self.click_if_visible(L.COOKIE_ACCEPT_BTN, timeout=3)
+        except Exception:
+            pass
+
+    @allure.step("Проверить, что открыта страница App")
+    def check_page_opened(self):
+        WebDriverWait(self.driver, 20).until(EC.url_contains("/app"))
+        assert "/app" in self.driver.current_url, f"Открыт неверный URL: {self.driver.current_url}"
+        self.assert_element_present(L.DOWNLOAD_HEADING)
+
+    @allure.step("Проверить title и meta-description страницы App")
+    def check_meta(self):
+        title = self.driver.title.strip()
+        assert title, "Title страницы /app пуст"
+        assert "allsports" in title.lower(), f"Title не содержит Allsports: {title}"
+
+        description = self.driver.execute_script(
+            "const m = document.querySelector('meta[name=\"description\"]');"
+            "return m ? (m.getAttribute('content') || '').trim() : '';"
+        )
+        assert description, "meta description страницы /app пустой"
+
+    @allure.step("Проверить ссылки на магазины приложений")
+    def check_store_links(self):
+        apple = self.driver.find_elements(*L.APPLE_LINKS)
+        google = self.driver.find_elements(*L.GOOGLE_LINKS)
+        huawei = self.driver.find_elements(*L.HUAWEI_LINKS)
+
+        assert apple, "Ссылки AppStore не найдены на /app"
+        assert google, "Ссылки Google Play не найдены на /app"
+        assert huawei, "Ссылки AppGallery не найдены на /app"
+
+        for el in apple:
+            href = (el.get_attribute("href") or "").strip()
+            assert "apps.apple.com" in href, f"Некорректная ссылка AppStore: {href}"
+        for el in google:
+            href = (el.get_attribute("href") or "").strip()
+            assert "play.google.com" in href, f"Некорректная ссылка Google Play: {href}"
+        for el in huawei:
+            href = (el.get_attribute("href") or "").strip()
+            assert "appgallery.huawei.com" in href, f"Некорректная ссылка AppGallery: {href}"
+
+    @allure.step("Проверить canonical страницы App")
+    def check_canonical(self):
+        canonical = self.driver.find_element(*L.CANONICAL_LINK).get_attribute("href") or ""
+        assert canonical, "Canonical ссылка отсутствует на /app"
+        current = self._normalize_url(self.driver.current_url)
+        canonical_normalized = self._normalize_url(canonical)
+        assert canonical_normalized == current, (
+            f"Canonical не совпадает с текущим URL: canonical={canonical_normalized}, current={current}"
+        )
+
+    @allure.step("Проверить отсутствие критичных console errors на /app")
+    def check_no_severe_console_errors(self):
+        # Небольшая пауза, чтобы браузер успел отдать финальные логи после гидрации.
+        time.sleep(0.3)
+        logs = self.driver.get_log("browser")
+        filtered = self._filtered_console_errors(logs)
+        assert not filtered, f"SEVERE ошибки в консоли /app: {filtered}"

--- a/pages/new_web_site/facilities.py
+++ b/pages/new_web_site/facilities.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import time
 import allure
+from selenium.common.exceptions import StaleElementReferenceException
+from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
@@ -98,6 +100,177 @@ class FacilitiesPage(BasePage):
         href = self.driver.find_element(*L.OBJECTS_TABLE_SECTION).get_attribute("href") or ""
         assert L.TABLE_URL_SUFFIX in href, f"Ссылка на таблицу объектов некорректна: {href}"
 
+    @allure.step("Открыть страницу 'Список объектов (таблица)'")
+    def open_table_page(self):
+        base_url = getattr(self.driver, "base_url", "https://www.allsports.by/ru-by").rstrip("/")
+        self.driver.get(f"{base_url}{L.TABLE_URL_SUFFIX}")
+        WebDriverWait(self.driver, 20).until(EC.url_contains(L.TABLE_URL_SUFFIX))
+        WebDriverWait(self.driver, 25).until(
+            lambda d: len(d.find_elements(*L.FACILITIES_TABLE_ROWS)) > 0
+        )
+        return self
+
+    def _visible_table_rows_count(self, retries=6):
+        for _ in range(retries):
+            rows = self.driver.find_elements(*L.FACILITIES_TABLE_ROWS)
+            visible = 0
+            stale = False
+            for row in rows:
+                try:
+                    if row.is_displayed():
+                        visible += 1
+                except StaleElementReferenceException:
+                    stale = True
+                    break
+            if not stale:
+                return visible
+            time.sleep(0.25)
+        return 0
+
+    def _open_table_filter_modal(self):
+        filter_btn = WebDriverWait(self.driver, 15).until(
+            EC.element_to_be_clickable(L.TABLE_FILTER_BUTTON)
+        )
+        self.driver.execute_script("arguments[0].click();", filter_btn)
+        WebDriverWait(self.driver, 15).until(
+            EC.visibility_of_element_located(L.TABLE_FILTER_MODAL_ROOT)
+        )
+
+    def _close_table_filter_modal_apply(self):
+        apply_btn = WebDriverWait(self.driver, 15).until(
+            EC.element_to_be_clickable(L.TABLE_FILTER_APPLY)
+        )
+        self.driver.execute_script("arguments[0].click();", apply_btn)
+        WebDriverWait(self.driver, 15).until(
+            EC.invisibility_of_element_located(L.TABLE_FILTER_MODAL_ROOT)
+        )
+        # Даем таблице время пересчитать выдачу.
+        time.sleep(0.6)
+        WebDriverWait(self.driver, 20).until(
+            lambda d: len(d.find_elements(*L.FACILITIES_TABLE_ROWS)) > 0
+        )
+
+    def _option_xpath(self, section_title, option_text):
+        return (
+            "//div[contains(@class,'map-filter-modal')]"
+            f"//p[normalize-space()='{section_title}']/following-sibling::ul[1]"
+            f"//li[.//span[contains(normalize-space(),\"{option_text}\")]]"
+        )
+
+    def _show_all_xpath(self, section_title):
+        return (
+            "//div[contains(@class,'map-filter-modal')]"
+            f"//p[normalize-space()='{section_title}']/following-sibling::ul[1]"
+            "//li[contains(@class,'show-all')]"
+        )
+
+    def _is_option_checked(self, section_title, option_text):
+        li = WebDriverWait(self.driver, 10).until(
+            EC.presence_of_element_located((By.XPATH, self._option_xpath(section_title, option_text)))
+        )
+        label = li.find_element(By.CSS_SELECTOR, "label.circle-checkbox")
+        classes = (label.get_attribute("class") or "").strip()
+        return "circle-checkbox_checked" in classes
+
+    def _select_filter_option(self, section_title, option_text, show_all=False):
+        if show_all:
+            show_all_xpath = self._show_all_xpath(section_title)
+            show_all_items = self.driver.find_elements(By.XPATH, show_all_xpath)
+            if show_all_items:
+                self.driver.execute_script("arguments[0].click();", show_all_items[0])
+                time.sleep(0.2)
+
+        option = WebDriverWait(self.driver, 10).until(
+            EC.presence_of_element_located((By.XPATH, self._option_xpath(section_title, option_text)))
+        )
+        self.driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", option)
+        self.driver.execute_script("arguments[0].click();", option)
+        WebDriverWait(self.driver, 8).until(
+            lambda d: self._is_option_checked(section_title, option_text)
+        )
+
+    @allure.step("Применить одиночный фильтр таблицы: {1} -> {2}")
+    def check_table_single_filter_value(self, section_title, option_text, show_all=False):
+        baseline_rows = self._visible_table_rows_count()
+        assert baseline_rows > 0, "Базовый набор таблицы пуст"
+
+        self._open_table_filter_modal()
+        self._select_filter_option(section_title, option_text, show_all=show_all)
+        self._close_table_filter_modal_apply()
+
+        filtered_rows = self._visible_table_rows_count()
+        assert filtered_rows > 0, (
+            f"После фильтра '{section_title}: {option_text}' не осталось отображаемых строк"
+        )
+        assert filtered_rows <= baseline_rows, (
+            f"Фильтр '{section_title}: {option_text}' расширил выдачу: "
+            f"до={baseline_rows}, после={filtered_rows}"
+        )
+        assert filtered_rows < baseline_rows, (
+            f"Фильтр '{section_title}: {option_text}' не сузил выдачу: "
+            f"до={baseline_rows}, после={filtered_rows}"
+        )
+
+    @allure.step("Применить комбинацию фильтров таблицы ({1})")
+    def check_table_filter_combination(self, filters):
+        baseline_rows = self._visible_table_rows_count()
+        assert baseline_rows > 0, "Базовый набор таблицы пуст"
+
+        self._open_table_filter_modal()
+        for flt in filters:
+            self._select_filter_option(
+                flt["section"],
+                flt["option"],
+                show_all=flt.get("show_all", False),
+            )
+        self._close_table_filter_modal_apply()
+
+        filtered_rows = self._visible_table_rows_count()
+        assert filtered_rows > 0, "После применения комбинации фильтров выдача пустая"
+        assert filtered_rows <= baseline_rows, (
+            f"Комбинация фильтров не должна расширять выдачу: "
+            f"до={baseline_rows}, после={filtered_rows}"
+        )
+        assert filtered_rows < baseline_rows, (
+            f"Комбинация фильтров не сузила выдачу: до={baseline_rows}, после={filtered_rows}"
+        )
+
+    @allure.step("Сбросить фильтры и вернуть baseline набор")
+    def check_table_reset_returns_baseline(self, filters, max_attempts=2):
+        baseline_rows = self._visible_table_rows_count()
+        assert baseline_rows > 0, "Базовый набор таблицы пуст"
+
+        self._open_table_filter_modal()
+        for flt in filters:
+            self._select_filter_option(
+                flt["section"],
+                flt["option"],
+                show_all=flt.get("show_all", False),
+            )
+        self._close_table_filter_modal_apply()
+
+        filtered_rows = self._visible_table_rows_count()
+        assert filtered_rows < baseline_rows, (
+            f"Комбинация перед reset не сузила выдачу: до={baseline_rows}, после={filtered_rows}"
+        )
+
+        restored_rows = filtered_rows
+        for _ in range(max_attempts):
+            self._open_table_filter_modal()
+            reset_btn = WebDriverWait(self.driver, 10).until(
+                EC.element_to_be_clickable(L.TABLE_FILTER_RESET)
+            )
+            self.driver.execute_script("arguments[0].click();", reset_btn)
+            time.sleep(0.2)
+            self._close_table_filter_modal_apply()
+            restored_rows = self._visible_table_rows_count()
+            if restored_rows == baseline_rows:
+                break
+
+        assert restored_rows == baseline_rows, (
+            f"После reset baseline не восстановлен: baseline={baseline_rows}, current={restored_rows}"
+        )
+
     @allure.step("Проверить полный сценарий фильтрации на странице 'Список объектов (таблица)'")
     def check_full_table_filters_flow(self):
         self._safe_scroll(L.OBJECTS_TABLE_SECTION)
@@ -111,7 +284,7 @@ class FacilitiesPage(BasePage):
         WebDriverWait(self.driver, 25).until(
             lambda d: len(d.find_elements(*L.FACILITIES_TABLE_ROWS)) > 0
         )
-        baseline_rows = len(self.driver.find_elements(*L.FACILITIES_TABLE_ROWS))
+        baseline_rows = self._visible_table_rows_count()
         assert baseline_rows > 0, "Таблица объектов не загружена"
 
         # Проверяем поиск
@@ -123,7 +296,7 @@ class FacilitiesPage(BasePage):
         WebDriverWait(self.driver, 15).until(
             lambda d: len(d.find_elements(*L.FACILITIES_TABLE_ROWS)) > 0
         )
-        filtered_rows = len(self.driver.find_elements(*L.FACILITIES_TABLE_ROWS))
+        filtered_rows = self._visible_table_rows_count()
         assert filtered_rows <= baseline_rows, (
             f"Поиск не сузил выборку: до={baseline_rows}, после={filtered_rows}"
         )

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,5 +15,6 @@ markers =
     schedule: full regression run for cron/scheduled execution
     smoke: lightweight post-release verification suite
     live_api: tests that perform real API POST checks and may write data
+    release_gate: release blocker suite (fast critical checks before merge/release)
 
 addopts = -s -v --alluredir=allure-results

--- a/test_new_web_site/test_app_page.py
+++ b/test_new_web_site/test_app_page.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+import allure
+import pytest
+import requests
+
+from pages.new_web_site.app_page import AppPage
+
+
+pytestmark = [pytest.mark.release_gate]
+
+
+@allure.feature("App Page")
+@allure.severity("Blocker")
+@allure.story("Открытие и базовая структура страницы /app")
+def test_app_page_open_and_structure(driver):
+    page = AppPage(driver)
+    page.open()
+    page.accept_cookie_consent()
+    page.check_page_opened()
+
+
+@allure.feature("App Page")
+@allure.severity("Critical")
+@allure.story("Ссылки на магазины приложений присутствуют и корректны")
+def test_app_page_store_links(driver):
+    page = AppPage(driver)
+    page.open()
+    page.accept_cookie_consent()
+    page.check_store_links()
+
+
+@allure.feature("App Page")
+@allure.severity("Normal")
+@allure.story("Проверка canonical и meta тегов")
+def test_app_page_canonical_and_meta(driver):
+    page = AppPage(driver)
+    page.open()
+    page.accept_cookie_consent()
+    page.check_meta()
+    page.check_canonical()
+
+
+@allure.feature("App Page")
+@allure.severity("Normal")
+@allure.story("Проверка отсутствия критичных ошибок в консоли")
+def test_app_page_console_errors(driver):
+    page = AppPage(driver)
+    page.open()
+    page.accept_cookie_consent()
+    page.check_no_severe_console_errors()
+
+
+@allure.feature("App Page")
+@allure.severity("Critical")
+@allure.story("Проверка HTTP статуса страницы /app")
+def test_app_page_http_status_200():
+    response = requests.get("https://www.allsports.by/ru-by/app", timeout=20, allow_redirects=True)
+    assert response.status_code == 200, f"/ru-by/app returned {response.status_code}"

--- a/test_new_web_site/test_endpoints_and_console.py
+++ b/test_new_web_site/test_endpoints_and_console.py
@@ -6,6 +6,9 @@ import requests
 from selenium.webdriver.common.by import By
 
 
+pytestmark = [pytest.mark.release_gate]
+
+
 PUBLIC_ENDPOINTS = [
     "https://www.allsports.fit/by/",
     "https://www.allsports.by/ru-by/",

--- a/test_new_web_site/test_facilities_page.py
+++ b/test_new_web_site/test_facilities_page.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import allure
+import pytest
 from pages.new_web_site.facilities import FacilitiesPage
 
 
@@ -66,6 +67,7 @@ def test_facilities_objects_table_block(driver):
 @allure.feature('Facilities Page')
 @allure.severity('Critical')
 @allure.story('Полный базовый сценарий страницы Объекты')
+@pytest.mark.release_gate
 def test_facilities_full_flow(driver):
     page = FacilitiesPage(driver)
     page.open()
@@ -81,9 +83,93 @@ def test_facilities_full_flow(driver):
 @allure.feature('Facilities Page')
 @allure.severity('Critical')
 @allure.story('Полная проверка фильтров и поиска в таблице объектов')
+@pytest.mark.release_gate
 def test_facilities_table_filters_full_flow(driver):
     page = FacilitiesPage(driver)
     page.open()
     page.accept_cookie_consent()
     page.check_page_opened()
     page.check_full_table_filters_flow()
+
+
+@allure.feature('Facilities Page')
+@allure.severity('Critical')
+@allure.story("Таблица объектов — отдельный фильтр: Город = Гомель")
+@pytest.mark.release_gate
+def test_facilities_table_single_filter_city_gomel(driver):
+    page = FacilitiesPage(driver)
+    page.open_table_page()
+    page.accept_cookie_consent()
+    page.check_table_single_filter_value("Город", "Гомель", show_all=True)
+
+
+@allure.feature('Facilities Page')
+@allure.severity('Critical')
+@allure.story("Таблица объектов — отдельный фильтр: Активность = Аквааэробика")
+@pytest.mark.release_gate
+def test_facilities_table_single_filter_activity_aqua(driver):
+    page = FacilitiesPage(driver)
+    page.open_table_page()
+    page.accept_cookie_consent()
+    page.check_table_single_filter_value("Активности", "Аквааэробика", show_all=True)
+
+
+@allure.feature('Facilities Page')
+@allure.severity('Critical')
+@allure.story("Таблица объектов — отдельный фильтр: Активность = Аргентинское танго")
+@pytest.mark.release_gate
+def test_facilities_table_single_filter_activity_tango(driver):
+    page = FacilitiesPage(driver)
+    page.open_table_page()
+    page.accept_cookie_consent()
+    page.check_table_single_filter_value("Активности", "Аргентинское танго", show_all=True)
+
+
+@allure.feature('Facilities Page')
+@allure.severity('Critical')
+@allure.story("Таблица объектов — комбинация 2 фильтров (Город + Активность)")
+@pytest.mark.release_gate
+def test_facilities_table_filters_combination_two(driver):
+    page = FacilitiesPage(driver)
+    page.open_table_page()
+    page.accept_cookie_consent()
+    page.check_table_filter_combination(
+        [
+            {"section": "Город", "option": "Гомель", "show_all": True},
+            {"section": "Активности", "option": "Аквааэробика", "show_all": True},
+        ]
+    )
+
+
+@allure.feature('Facilities Page')
+@allure.severity('Critical')
+@allure.story("Таблица объектов — комбинация 3 фильтров (Город + 2 активности)")
+@pytest.mark.release_gate
+def test_facilities_table_filters_combination_three(driver):
+    page = FacilitiesPage(driver)
+    page.open_table_page()
+    page.accept_cookie_consent()
+    page.check_table_filter_combination(
+        [
+            {"section": "Город", "option": "Гомель", "show_all": True},
+            {"section": "Активности", "option": "Аквааэробика", "show_all": True},
+            {"section": "Активности", "option": "Аргентинское танго", "show_all": True},
+        ]
+    )
+
+
+@allure.feature('Facilities Page')
+@allure.severity('Critical')
+@allure.story("Таблица объектов — reset фильтров возвращает baseline набор")
+@pytest.mark.release_gate
+def test_facilities_table_reset_returns_baseline(driver):
+    page = FacilitiesPage(driver)
+    page.open_table_page()
+    page.accept_cookie_consent()
+    page.check_table_reset_returns_baseline(
+        [
+            {"section": "Город", "option": "Гомель", "show_all": True},
+            {"section": "Активности", "option": "Аквааэробика", "show_all": True},
+        ],
+        max_attempts=2,
+    )

--- a/test_new_web_site/test_internal_links_crawler.py
+++ b/test_new_web_site/test_internal_links_crawler.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+import re
+from urllib.parse import urljoin, urlparse, urlunparse
+
+import allure
+import pytest
+import requests
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+
+pytestmark = [pytest.mark.release_gate]
+
+
+KEY_PAGES = [
+    "https://www.allsports.by/ru-by/",
+    "https://www.allsports.by/ru-by/facilities",
+    "https://www.allsports.by/ru-by/facilities-table",
+    "https://www.allsports.by/ru-by/levels",
+    "https://www.allsports.by/ru-by/companies",
+    "https://www.allsports.by/ru-by/partners",
+    "https://www.allsports.by/ru-by/contacts",
+    "https://www.allsports.by/ru-by/app",
+]
+
+INTERNAL_HOSTS = {"www.allsports.by", "allsports.by"}
+SKIP_PREFIXES = ("mailto:", "tel:", "javascript:", "#")
+ASSET_EXTENSIONS = (
+    ".js",
+    ".css",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".webp",
+    ".svg",
+    ".ico",
+    ".woff",
+    ".woff2",
+    ".ttf",
+    ".map",
+)
+
+
+def _normalize_url(url: str) -> str:
+    parsed = urlparse(url)
+    path = parsed.path or "/"
+    if path != "/" and path.endswith("/"):
+        path = path[:-1]
+    return urlunparse((parsed.scheme, parsed.netloc.lower(), path, "", "", ""))
+
+
+def _extract_canonical_href(html: str) -> str | None:
+    for match in re.finditer(r"<link[^>]+>", html, flags=re.IGNORECASE):
+        tag = match.group(0)
+        if not re.search(r"rel\s*=\s*['\"][^'\"]*canonical[^'\"]*['\"]", tag, flags=re.IGNORECASE):
+            continue
+        href_match = re.search(r"href\s*=\s*['\"]([^'\"]+)['\"]", tag, flags=re.IGNORECASE)
+        if href_match:
+            return href_match.group(1).strip()
+    return None
+
+
+def _accept_cookie_if_present(driver):
+    try:
+        WebDriverWait(driver, 2).until(
+            EC.element_to_be_clickable((By.CSS_SELECTOR, ".cookie-primary-modal__confirm"))
+        ).click()
+    except Exception:
+        pass
+
+
+def _collect_internal_links(driver):
+    links = set()
+    for page_url in KEY_PAGES:
+        driver.get(page_url)
+        _accept_cookie_if_present(driver)
+        WebDriverWait(driver, 20).until(EC.presence_of_element_located((By.TAG_NAME, "body")))
+
+        anchors = driver.find_elements(By.CSS_SELECTOR, "a[href]")
+        for anchor in anchors:
+            raw_href = (anchor.get_attribute("href") or "").strip()
+            if not raw_href:
+                continue
+            if raw_href.startswith(SKIP_PREFIXES):
+                continue
+
+            absolute = urljoin(page_url, raw_href)
+            parsed = urlparse(absolute)
+            if parsed.scheme not in ("http", "https"):
+                continue
+            if parsed.netloc.lower() not in INTERNAL_HOSTS:
+                continue
+
+            normalized = _normalize_url(absolute)
+            if "/_nuxt/" in normalized:
+                continue
+            if normalized.endswith(ASSET_EXTENSIONS):
+                continue
+
+            links.add(normalized)
+    return sorted(links)
+
+
+@allure.feature("Links")
+@allure.severity("Critical")
+@allure.story("Crawler внутренних ссылок: HTTP + canonical + final URL")
+def test_internal_links_crawler_http_and_canonical(driver):
+    links = _collect_internal_links(driver)
+    assert links, "Crawler не собрал ни одной внутренней ссылки"
+
+    bad_links = []
+
+    for link in links:
+        # 1) Проверяем, что ссылка не уходит в 4xx/5xx сразу.
+        first = requests.get(link, timeout=20, allow_redirects=False)
+        if first.status_code >= 400:
+            bad_links.append(f"{link} -> first_status={first.status_code}")
+            continue
+
+        # 2) Проверяем финальный переход (с учетом редиректов).
+        final = requests.get(link, timeout=20, allow_redirects=True)
+        if final.status_code >= 400:
+            bad_links.append(f"{link} -> final_status={final.status_code}")
+            continue
+
+        final_url = _normalize_url(final.url)
+
+        # 3) Проверяем canonical на HTML страницах.
+        content_type = (final.headers.get("Content-Type") or "").lower()
+        if "text/html" in content_type:
+            canonical_href = _extract_canonical_href(final.text or "")
+            if canonical_href:
+                canonical_abs = urljoin(final.url, canonical_href)
+                canonical_url = _normalize_url(canonical_abs)
+                if canonical_url != final_url:
+                    bad_links.append(
+                        f"{link} -> canonical_mismatch: canonical={canonical_url} final={final_url}"
+                    )
+
+    assert not bad_links, "Обнаружены проблемы внутренних ссылок:\n" + "\n".join(bad_links[:40])

--- a/test_new_web_site/test_smoke_post_release.py
+++ b/test_new_web_site/test_smoke_post_release.py
@@ -9,6 +9,7 @@ from pages.new_web_site.smoke_pages import SmokePages
 @allure.story('Post-release: ключевые UI страницы')
 @allure.severity('Blocker')
 @pytest.mark.smoke
+@pytest.mark.release_gate
 def test_post_release_smoke_ui(driver):
     page = SmokePages(driver)
     page.run_post_release_smoke_ui()
@@ -18,6 +19,7 @@ def test_post_release_smoke_ui(driver):
 @allure.story('Post-release: доступность критичных служебных страниц')
 @allure.severity('Critical')
 @pytest.mark.smoke
+@pytest.mark.release_gate
 def test_post_release_smoke_http(driver):
     page = SmokePages(driver)
     page.run_post_release_smoke_http()


### PR DESCRIPTION
## What was done (Phase A)
- Added full `/ru-by/app` test package.
- Added dynamic internal-links crawler test:
  - collects `a[href]` from key pages,
  - skips `mailto/tel/#/javascript`,
  - verifies internal links are not `4xx/5xx`,
  - checks canonical against final URL.
- Strengthened `facilities-table` coverage:
  - single-filter checks by values,
  - combinations of 2 and 3 filters,
  - reset-to-baseline verification (with retry for UI stability).
- Introduced unified release marker: `release_gate`.

## Validation
- Targeted new suites: `13 passed`.
- Full release gate run: `43 passed`.

## Run command
```bash
pytest -m release_gate --headless -q
```