### PR TITLE
Disable SB scheduled form submissions from release gate

### DIFF
--- a/.github/workflows/sb_browser_matrix.yml
+++ b/.github/workflows/sb_browser_matrix.yml
@@ -2,8 +2,6 @@ name: SportBenefit Browser Matrix
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 5 * * 1-5"
 
 jobs:
   sb-release-gate:
@@ -36,7 +34,7 @@ jobs:
 
       - name: Run SportBenefit release gate
         run: >
-          pytest test_new_web_site_sb -m release_gate --headless --b ${{ matrix.browser }}
+          pytest test_new_web_site_sb -m "release_gate and not live_api and not form_submission" --headless --b ${{ matrix.browser }}
           --base-url https://www.sportbenefit.eu
 
       - name: Upload Allure results

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,6 +16,7 @@ markers =
     schedule: full regression run for cron/scheduled execution
     smoke: lightweight post-release verification suite
     live_api: tests that perform real API POST checks and may write data
+    form_submission: tests that click real UI form submit and can generate outbound contact requests
     release_gate: release blocker suite (fast critical checks before merge/release)
     cyrillic_gate: fast checks for cyrillic text leakage on EN pages
     console_strict: strict browser-console quality gate with minimal filtering

--- a/test_new_web_site_sb/test_companies_page_sb.py
+++ b/test_new_web_site_sb/test_companies_page_sb.py
@@ -30,7 +30,7 @@ def test_companies_offer_modal_sb(driver):
 
 @allure.feature("Companies SB Forms")
 @allure.severity("Critical")
-@pytest.mark.release_gate
+@pytest.mark.form_submission
 def test_companies_get_offer_submit_endpoint_sb(driver):
     """Проверка отправки формы Get an Offer на корректный endpoint /contact/get_offer."""
     page = CompaniesPageSb(driver)
@@ -58,7 +58,7 @@ def test_companies_get_offer_submit_endpoint_sb(driver):
 
 @allure.feature("Companies SB Forms")
 @allure.severity("Critical")
-@pytest.mark.release_gate
+@pytest.mark.form_submission
 def test_companies_ask_question_submit_endpoint_sb(driver):
     """Проверка отправки формы Ask Us a Question на endpoint /contact/ask_question."""
     page = CompaniesPageSb(driver)

--- a/test_new_web_site_sb/test_contacts_page_sb.py
+++ b/test_new_web_site_sb/test_contacts_page_sb.py
@@ -48,7 +48,7 @@ def test_contacts_map_visible_sb(driver):
 
 @allure.feature("Contacts SB")
 @allure.severity("Normal")
-@pytest.mark.release_gate
+@pytest.mark.form_submission
 def test_contacts_invalid_validation_sb(driver):
     """Проверка валидации невалидного телефона и email на странице Contacts."""
     page = ContactsPageSb(driver)
@@ -59,7 +59,7 @@ def test_contacts_invalid_validation_sb(driver):
 
 @allure.feature("Contacts SB Forms")
 @allure.severity("Critical")
-@pytest.mark.release_gate
+@pytest.mark.form_submission
 def test_contacts_inline_form_blocks_invalid_submit_sb(driver):
     """Проверка, что inline-форма блокирует отправку при невалидных данных."""
     page = ContactsPageSb(driver)
@@ -91,7 +91,7 @@ def test_contacts_inline_form_blocks_invalid_submit_sb(driver):
 
 @allure.feature("Contacts SB Forms")
 @allure.severity("Critical")
-@pytest.mark.release_gate
+@pytest.mark.form_submission
 def test_contacts_inline_form_submit_endpoint_and_success_state_sb(driver):
     """Проверка endpoint и успешного состояния после отправки inline-формы Contacts."""
     page = ContactsPageSb(driver)
@@ -130,7 +130,7 @@ def test_contacts_inline_form_submit_endpoint_and_success_state_sb(driver):
 
 @allure.feature("Contacts SB Forms")
 @allure.severity("Critical")
-@pytest.mark.release_gate
+@pytest.mark.form_submission
 def test_contacts_get_offer_modal_submit_endpoint_sb(driver):
     """Проверка отправки модальной формы Get an Offer на endpoint /contact/get_offer."""
     page = ContactsPageSb(driver)
@@ -158,7 +158,7 @@ def test_contacts_get_offer_modal_submit_endpoint_sb(driver):
 
 @allure.feature("Contacts SB Forms")
 @allure.severity("Critical")
-@pytest.mark.release_gate
+@pytest.mark.form_submission
 def test_contacts_ask_question_modal_submit_endpoint_sb(driver):
     """Проверка отправки модальной формы Ask Us a Question на endpoint /contact/ask_question."""
     page = ContactsPageSb(driver)

--- a/test_new_web_site_sb/test_form_post_submit_ux_sb.py
+++ b/test_new_web_site_sb/test_form_post_submit_ux_sb.py
@@ -69,7 +69,7 @@ def _fill_valid_modal_form(driver, kind: str, suffix: str):
 
 @allure.feature("SB Forms UX")
 @allure.severity("Critical")
-@pytest.mark.release_gate
+@pytest.mark.form_submission
 @pytest.mark.parametrize("case", FORM_CASES, ids=[c["id"] for c in FORM_CASES])
 def test_modal_submit_success_feedback_sb(driver, case):
     """Проверка post-submit поведения формы при успешной отправке."""
@@ -91,7 +91,7 @@ def test_modal_submit_success_feedback_sb(driver, case):
 
 @allure.feature("SB Forms UX")
 @allure.severity("Critical")
-@pytest.mark.release_gate
+@pytest.mark.form_submission
 @pytest.mark.parametrize("status_code", [400, 500])
 @pytest.mark.parametrize("case", FORM_CASES, ids=[c["id"] for c in FORM_CASES])
 def test_modal_submit_backend_failure_feedback_sb(driver, case, status_code):

--- a/test_new_web_site_sb/test_form_validation_matrix_sb.py
+++ b/test_new_web_site_sb/test_form_validation_matrix_sb.py
@@ -100,7 +100,7 @@ def _fill_modal_form(driver, form_kind: str, invalid_case: str):
 
 @allure.feature("SB Validation Matrix")
 @allure.severity("Critical")
-@pytest.mark.release_gate
+@pytest.mark.form_submission
 @pytest.mark.parametrize("form_case", FORM_CASES, ids=[c["form_kind"] for c in FORM_CASES])
 @pytest.mark.parametrize("invalid_case", INVALID_CASES)
 def test_modal_validation_matrix_blocks_invalid_submit_sb(driver, form_case, invalid_case):

--- a/test_new_web_site_sb/test_live_ui_forms_e2e_sb.py
+++ b/test_new_web_site_sb/test_live_ui_forms_e2e_sb.py
@@ -24,7 +24,7 @@ from test_new_web_site_sb.form_helpers_sb import (
 )
 
 
-pytestmark = [pytest.mark.live_api, pytest.mark.release_gate]
+pytestmark = [pytest.mark.live_api, pytest.mark.form_submission]
 
 
 FORM_CASES = [

--- a/test_new_web_site_sb/test_main_page_sb.py
+++ b/test_new_web_site_sb/test_main_page_sb.py
@@ -50,7 +50,7 @@ def test_main_page_offer_modal_flow_sb(driver):
 
 @allure.feature("Main SB Forms")
 @allure.severity("Critical")
-@pytest.mark.release_gate
+@pytest.mark.form_submission
 def test_main_get_offer_form_submit_endpoint_sb(driver):
     """Проверка отправки формы Get an Offer с главной на endpoint /contact/get_offer."""
     page = MainPageSb(driver)
@@ -78,7 +78,7 @@ def test_main_get_offer_form_submit_endpoint_sb(driver):
 
 @allure.feature("Main SB Forms")
 @allure.severity("Critical")
-@pytest.mark.release_gate
+@pytest.mark.form_submission
 def test_main_ask_question_form_submit_endpoint_sb(driver):
     """Проверка отправки формы Ask Us a Question с главной на endpoint /contact/ask_question."""
     page = MainPageSb(driver)

--- a/test_new_web_site_sb/test_partners_page_sb.py
+++ b/test_new_web_site_sb/test_partners_page_sb.py
@@ -30,7 +30,7 @@ def test_partners_become_partner_modal_sb(driver):
 
 @allure.feature("Partners SB Forms")
 @allure.severity("Critical")
-@pytest.mark.release_gate
+@pytest.mark.form_submission
 def test_partners_get_offer_submit_endpoint_sb(driver):
     """Проверка отправки формы Get an Offer на странице Partners."""
     page = PartnersPageSb(driver)
@@ -58,7 +58,7 @@ def test_partners_get_offer_submit_endpoint_sb(driver):
 
 @allure.feature("Partners SB Forms")
 @allure.severity("Critical")
-@pytest.mark.release_gate
+@pytest.mark.form_submission
 def test_partners_become_partner_submit_endpoint_sb(driver):
     """Проверка отправки формы Become a Partner на endpoint /contact/become_partner."""
     page = PartnersPageSb(driver)
@@ -88,7 +88,7 @@ def test_partners_become_partner_submit_endpoint_sb(driver):
 
 @allure.feature("Partners SB Forms")
 @allure.severity("Critical")
-@pytest.mark.release_gate
+@pytest.mark.form_submission
 def test_partners_ask_question_submit_endpoint_sb(driver):
     """Проверка отправки формы Ask Us a Question на странице Partners."""
     page = PartnersPageSb(driver)


### PR DESCRIPTION
This change disables cron execution for SB browser matrix and removes real form-submission tests from release_gate by introducing form_submission marker exclusion.