### PR TITLE
Refactor test_new_web_site to Page Object style

### DIFF
--- a/pages/new_web_site/app_page.py
+++ b/pages/new_web_site/app_page.py
@@ -3,6 +3,7 @@ import time
 from urllib.parse import urlparse, urlunparse
 
 import allure
+import requests
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
@@ -105,3 +106,8 @@ class AppPage(BasePage):
         logs = self.driver.get_log("browser")
         filtered = self._filtered_console_errors(logs)
         assert not filtered, f"SEVERE ошибки в консоли /app: {filtered}"
+
+    @allure.step("Проверить HTTP статус страницы App")
+    def check_http_status_200(self, timeout=20):
+        response = requests.get(L.BASE_URL, timeout=timeout, allow_redirects=True)
+        assert response.status_code == 200, f"{L.BASE_URL} returned {response.status_code}"

--- a/pages/new_web_site/companies.py
+++ b/pages/new_web_site/companies.py
@@ -1097,6 +1097,19 @@ class CompaniesPage(BasePage):
             self._check_subscription_cards(in_archive=True)
             self.close_archive_modal()
 
+    @allure.step("Проверить обычные карточки подписок")
+    def check_regular_subscription_cards(self):
+        self._check_subscription_cards(in_archive=False)
+
+    @allure.step("Проверить архивные карточки подписок")
+    def check_archive_subscription_cards(self):
+        if not self.open_archive_modal():
+            return
+        try:
+            self._check_subscription_cards(in_archive=True)
+        finally:
+            self.close_archive_modal()
+
     # === ВСПОМОГАТЕЛЬНЫЕ ===
     def _check_subscription_cards(self, in_archive=False):
         """Обход карточек, переход по 2 ссылкам ('Объекты подписки' и 'Список объектов (таблица)')."""
@@ -1279,7 +1292,6 @@ class CompaniesPage(BasePage):
             EC.invisibility_of_element_located(L.SUBSCRIPTIONS_ARCHIVE_MODAL)
         )
         time.sleep(0.6)
-
 
 
 

--- a/pages/new_web_site/internal_links_crawler.py
+++ b/pages/new_web_site/internal_links_crawler.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+import re
+from urllib.parse import urljoin, urlparse, urlunparse
+
+import requests
+from selenium.webdriver.common.by import By
+
+from helpers.base import BasePage
+
+
+class InternalLinksCrawlerPage(BasePage):
+    KEY_PAGES = [
+        "https://www.allsports.by/ru-by/",
+        "https://www.allsports.by/ru-by/facilities",
+        "https://www.allsports.by/ru-by/facilities-table",
+        "https://www.allsports.by/ru-by/levels",
+        "https://www.allsports.by/ru-by/companies",
+        "https://www.allsports.by/ru-by/partners",
+        "https://www.allsports.by/ru-by/contacts",
+        "https://www.allsports.by/ru-by/app",
+    ]
+    INTERNAL_HOSTS = {"www.allsports.by", "allsports.by"}
+    SKIP_PREFIXES = ("mailto:", "tel:", "javascript:", "#")
+    ASSET_EXTENSIONS = (
+        ".js",
+        ".css",
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".webp",
+        ".svg",
+        ".ico",
+        ".woff",
+        ".woff2",
+        ".ttf",
+        ".map",
+    )
+
+    @staticmethod
+    def normalize_url(url: str) -> str:
+        parsed = urlparse(url)
+        path = parsed.path or "/"
+        if path != "/" and path.endswith("/"):
+            path = path[:-1]
+        return urlunparse((parsed.scheme, parsed.netloc.lower(), path, "", "", ""))
+
+    @staticmethod
+    def extract_canonical_href(html: str) -> str | None:
+        for match in re.finditer(r"<link[^>]+>", html, flags=re.IGNORECASE):
+            tag = match.group(0)
+            if not re.search(r"rel\s*=\s*['\"][^'\"]*canonical[^'\"]*['\"]", tag, flags=re.IGNORECASE):
+                continue
+            href_match = re.search(r"href\s*=\s*['\"]([^'\"]+)['\"]", tag, flags=re.IGNORECASE)
+            if href_match:
+                return href_match.group(1).strip()
+        return None
+
+    def collect_internal_links(self):
+        links = set()
+        for page_url in self.KEY_PAGES:
+            self.driver.get(page_url)
+            self.click_if_visible((By.CSS_SELECTOR, ".cookie-primary-modal__confirm"), timeout=3)
+            self.wait_for_visible((By.TAG_NAME, "body"), timeout=20)
+
+            anchors = self.driver.find_elements(By.CSS_SELECTOR, "a[href]")
+            for anchor in anchors:
+                raw_href = (anchor.get_attribute("href") or "").strip()
+                if not raw_href or raw_href.startswith(self.SKIP_PREFIXES):
+                    continue
+
+                absolute = urljoin(page_url, raw_href)
+                parsed = urlparse(absolute)
+                if parsed.scheme not in ("http", "https"):
+                    continue
+                if parsed.netloc.lower() not in self.INTERNAL_HOSTS:
+                    continue
+
+                normalized = self.normalize_url(absolute)
+                if "/_nuxt/" in normalized:
+                    continue
+                if normalized.endswith(self.ASSET_EXTENSIONS):
+                    continue
+
+                links.add(normalized)
+        return sorted(links)
+
+    def check_internal_links_http_and_canonical(self):
+        links = self.collect_internal_links()
+        assert links, "Crawler не собрал ни одной внутренней ссылки"
+
+        bad_links = []
+        for link in links:
+            first = requests.get(link, timeout=20, allow_redirects=False)
+            if first.status_code >= 400:
+                bad_links.append(f"{link} -> first_status={first.status_code}")
+                continue
+
+            final = requests.get(link, timeout=20, allow_redirects=True)
+            if final.status_code >= 400:
+                bad_links.append(f"{link} -> final_status={final.status_code}")
+                continue
+
+            final_url = self.normalize_url(final.url)
+            content_type = (final.headers.get("Content-Type") or "").lower()
+            if "text/html" not in content_type:
+                continue
+
+            canonical_href = self.extract_canonical_href(final.text or "")
+            if not canonical_href:
+                continue
+
+            canonical_abs = urljoin(final.url, canonical_href)
+            canonical_url = self.normalize_url(canonical_abs)
+            if canonical_url != final_url:
+                bad_links.append(
+                    f"{link} -> canonical_mismatch: canonical={canonical_url} final={final_url}"
+                )
+
+        assert not bad_links, "Обнаружены проблемы внутренних ссылок:\n" + "\n".join(bad_links[:40])

--- a/pages/new_web_site/main_page.py
+++ b/pages/new_web_site/main_page.py
@@ -88,6 +88,19 @@ class MainPage(BasePage):
             self._check_subscription_cards(in_archive=True)
             self.close_archive_modal()
 
+    @allure.step("Проверить обычные карточки подписок")
+    def check_regular_subscription_cards(self):
+        self._check_subscription_cards(in_archive=False)
+
+    @allure.step("Проверить архивные карточки подписок")
+    def check_archive_subscription_cards(self):
+        if not self.open_archive_modal():
+            return
+        try:
+            self._check_subscription_cards(in_archive=True)
+        finally:
+            self.close_archive_modal()
+
     def _check_subscription_cards(self, in_archive=False):
         """Проверка всех карточек (название, тексты, ссылки)."""
         driver = self.driver

--- a/pages/new_web_site/site_health.py
+++ b/pages/new_web_site/site_health.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+import requests
+from selenium.webdriver.common.by import By
+
+from helpers.base import BasePage
+
+
+class SiteHealthPage(BasePage):
+    @staticmethod
+    def filtered_console_errors(raw_logs):
+        severe = [entry for entry in raw_logs if entry.get("level") == "SEVERE"]
+        filtered = []
+        for entry in severe:
+            msg = (entry.get("message") or "").lower()
+            source = (entry.get("source") or "").lower()
+            if "sentry" in msg:
+                continue
+            if "content security policy" in msg or "csp" in msg:
+                continue
+            if source in ("security", "network"):
+                continue
+            filtered.append(entry)
+        return filtered
+
+    def check_public_endpoint_status_200(self, url, timeout=20):
+        response = requests.get(url, timeout=timeout, allow_redirects=True)
+        assert response.status_code == 200, f"{url} returned {response.status_code}"
+
+    def check_options_endpoint_status_200(self, url, timeout=20):
+        response = requests.options(url, timeout=timeout)
+        assert response.status_code == 200, f"OPTIONS {url} returned {response.status_code}"
+
+    def check_get_method_guard(self, url, timeout=20, expected_status=405):
+        response = requests.get(url, timeout=timeout)
+        assert response.status_code == expected_status, (
+            f"GET {url} should be method-guarded ({expected_status}), got {response.status_code}"
+        )
+
+    def check_page_has_no_severe_console_errors(self, url):
+        self.driver.get(url)
+        self.click_if_visible((By.CSS_SELECTOR, ".cookie-primary-modal__confirm"), timeout=3)
+        logs = self.driver.get_log("browser")
+        filtered = self.filtered_console_errors(logs)
+        assert not filtered, f"Console SEVERE errors on {url}: {filtered}"

--- a/test_new_web_site/test_app_page.py
+++ b/test_new_web_site/test_app_page.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import allure
 import pytest
-import requests
 
 from pages.new_web_site.app_page import AppPage
 
@@ -54,5 +53,5 @@ def test_app_page_console_errors(driver):
 @allure.severity("Critical")
 @allure.story("Проверка HTTP статуса страницы /app")
 def test_app_page_http_status_200():
-    response = requests.get("https://www.allsports.by/ru-by/app", timeout=20, allow_redirects=True)
-    assert response.status_code == 200, f"/ru-by/app returned {response.status_code}"
+    page = AppPage(None)
+    page.check_http_status_200()

--- a/test_new_web_site/test_companies_page.py
+++ b/test_new_web_site/test_companies_page.py
@@ -544,13 +544,8 @@ def test_subscription_cards_texts_and_links(driver):
     page.open()
     page.accept_cookie_consent()
 
-    # Проверяем обычные карточки
-    page._check_subscription_cards(in_archive=False)
-
-    # Проверяем архивные карточки
-    page.open_archive_modal()
-    page._check_subscription_cards(in_archive=True)
-    page.close_archive_modal()
+    page.check_regular_subscription_cards()
+    page.check_archive_subscription_cards()
 
 
 @allure.feature("Companies Page")
@@ -564,7 +559,7 @@ def test_subscription_links_regular_cards(driver):
     page = CompaniesPage(driver)
     page.open()
     page.accept_cookie_consent()
-    page._check_subscription_cards(in_archive=False)
+    page.check_regular_subscription_cards()
 
 
 @allure.feature("Companies Page")
@@ -579,14 +574,7 @@ def test_subscription_links_archive_cards(driver):
     page.open()
     page.accept_cookie_consent()
 
-    # Открываем модалку архивных подписок
-    page.open_archive_modal()
-
-    # Проверяем переходы по ссылкам
-    page._check_subscription_cards(in_archive=True)
-
-    # Закрываем модалку
-    page.close_archive_modal()
+    page.check_archive_subscription_cards()
 
 
 @allure.feature("Companies Page")
@@ -617,13 +605,8 @@ def test_subscription_facilities_tables_load(driver):
     page.open()
     page.accept_cookie_consent()
 
-    # Проверяем таблицы обычных карточек
-    page._check_subscription_cards(in_archive=False)
-
-    # Проверяем таблицы архивных карточек
-    page.open_archive_modal()
-    page._check_subscription_cards(in_archive=True)
-    page.close_archive_modal()
+    page.check_regular_subscription_cards()
+    page.check_archive_subscription_cards()
 
 
 @allure.feature("Companies Page")
@@ -639,10 +622,5 @@ def test_subscription_card_texts_valid(driver):
     page.open()
     page.accept_cookie_consent()
 
-    # Проверяем тексты карточек обычных подписок
-    page._check_subscription_cards(in_archive=False)
-
-    # Проверяем тексты карточек архивных подписок
-    page.open_archive_modal()
-    page._check_subscription_cards(in_archive=True)
-    page.close_archive_modal()
+    page.check_regular_subscription_cards()
+    page.check_archive_subscription_cards()

--- a/test_new_web_site/test_endpoints_and_console.py
+++ b/test_new_web_site/test_endpoints_and_console.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 import allure
 import pytest
-import requests
-
-from selenium.webdriver.common.by import By
+from pages.new_web_site.site_health import SiteHealthPage
 
 
 pytestmark = [pytest.mark.release_gate]
@@ -43,58 +41,33 @@ UI_PAGES_FOR_CONSOLE = [
     "https://www.allsports.by/ru-by/contacts",
 ]
 
-
-def _filtered_console_errors(raw_logs):
-    severe = [entry for entry in raw_logs if entry.get("level") == "SEVERE"]
-    filtered = []
-    for entry in severe:
-        msg = (entry.get("message") or "").lower()
-        source = (entry.get("source") or "").lower()
-        if "sentry" in msg:
-            continue
-        if "content security policy" in msg or "csp" in msg:
-            continue
-        if source in ("security", "network"):
-            continue
-        filtered.append(entry)
-    return filtered
-
-
 @allure.feature("Endpoints")
 @allure.severity("Critical")
 @pytest.mark.parametrize("url", PUBLIC_ENDPOINTS)
 def test_public_endpoints_status_200(url):
-    response = requests.get(url, timeout=20, allow_redirects=True)
-    assert response.status_code == 200, f"{url} returned {response.status_code}"
+    page = SiteHealthPage(None)
+    page.check_public_endpoint_status_200(url)
 
 
 @allure.feature("Endpoints")
 @allure.severity("Critical")
 @pytest.mark.parametrize("url", API_ENDPOINTS)
 def test_contact_api_options(url):
-    response = requests.options(url, timeout=20)
-    assert response.status_code == 200, f"OPTIONS {url} returned {response.status_code}"
+    page = SiteHealthPage(None)
+    page.check_options_endpoint_status_200(url)
 
 
 @allure.feature("Endpoints")
 @allure.severity("Normal")
 @pytest.mark.parametrize("url", API_ENDPOINTS)
 def test_contact_api_get_method_guard(url):
-    response = requests.get(url, timeout=20)
-    assert response.status_code == 405, f"GET {url} should be method-guarded (405), got {response.status_code}"
+    page = SiteHealthPage(None)
+    page.check_get_method_guard(url)
 
 
 @allure.feature("Console")
 @allure.severity("Normal")
 @pytest.mark.parametrize("url", UI_PAGES_FOR_CONSOLE)
 def test_pages_have_no_severe_console_errors(driver, url):
-    driver.get(url)
-    try:
-        cookie = driver.find_element(By.CSS_SELECTOR, ".cookie-primary-modal__confirm")
-        cookie.click()
-    except Exception:
-        pass
-
-    logs = driver.get_log("browser")
-    filtered = _filtered_console_errors(logs)
-    assert not filtered, f"Console SEVERE errors on {url}: {filtered}"
+    page = SiteHealthPage(driver)
+    page.check_page_has_no_severe_console_errors(url)

--- a/test_new_web_site/test_internal_links_crawler.py
+++ b/test_new_web_site/test_internal_links_crawler.py
@@ -1,141 +1,16 @@
 # -*- coding: utf-8 -*-
-import re
-from urllib.parse import urljoin, urlparse, urlunparse
-
 import allure
 import pytest
-import requests
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import WebDriverWait
+
+from pages.new_web_site.internal_links_crawler import InternalLinksCrawlerPage
 
 
 pytestmark = [pytest.mark.release_gate]
-
-
-KEY_PAGES = [
-    "https://www.allsports.by/ru-by/",
-    "https://www.allsports.by/ru-by/facilities",
-    "https://www.allsports.by/ru-by/facilities-table",
-    "https://www.allsports.by/ru-by/levels",
-    "https://www.allsports.by/ru-by/companies",
-    "https://www.allsports.by/ru-by/partners",
-    "https://www.allsports.by/ru-by/contacts",
-    "https://www.allsports.by/ru-by/app",
-]
-
-INTERNAL_HOSTS = {"www.allsports.by", "allsports.by"}
-SKIP_PREFIXES = ("mailto:", "tel:", "javascript:", "#")
-ASSET_EXTENSIONS = (
-    ".js",
-    ".css",
-    ".png",
-    ".jpg",
-    ".jpeg",
-    ".webp",
-    ".svg",
-    ".ico",
-    ".woff",
-    ".woff2",
-    ".ttf",
-    ".map",
-)
-
-
-def _normalize_url(url: str) -> str:
-    parsed = urlparse(url)
-    path = parsed.path or "/"
-    if path != "/" and path.endswith("/"):
-        path = path[:-1]
-    return urlunparse((parsed.scheme, parsed.netloc.lower(), path, "", "", ""))
-
-
-def _extract_canonical_href(html: str) -> str | None:
-    for match in re.finditer(r"<link[^>]+>", html, flags=re.IGNORECASE):
-        tag = match.group(0)
-        if not re.search(r"rel\s*=\s*['\"][^'\"]*canonical[^'\"]*['\"]", tag, flags=re.IGNORECASE):
-            continue
-        href_match = re.search(r"href\s*=\s*['\"]([^'\"]+)['\"]", tag, flags=re.IGNORECASE)
-        if href_match:
-            return href_match.group(1).strip()
-    return None
-
-
-def _accept_cookie_if_present(driver):
-    try:
-        WebDriverWait(driver, 2).until(
-            EC.element_to_be_clickable((By.CSS_SELECTOR, ".cookie-primary-modal__confirm"))
-        ).click()
-    except Exception:
-        pass
-
-
-def _collect_internal_links(driver):
-    links = set()
-    for page_url in KEY_PAGES:
-        driver.get(page_url)
-        _accept_cookie_if_present(driver)
-        WebDriverWait(driver, 20).until(EC.presence_of_element_located((By.TAG_NAME, "body")))
-
-        anchors = driver.find_elements(By.CSS_SELECTOR, "a[href]")
-        for anchor in anchors:
-            raw_href = (anchor.get_attribute("href") or "").strip()
-            if not raw_href:
-                continue
-            if raw_href.startswith(SKIP_PREFIXES):
-                continue
-
-            absolute = urljoin(page_url, raw_href)
-            parsed = urlparse(absolute)
-            if parsed.scheme not in ("http", "https"):
-                continue
-            if parsed.netloc.lower() not in INTERNAL_HOSTS:
-                continue
-
-            normalized = _normalize_url(absolute)
-            if "/_nuxt/" in normalized:
-                continue
-            if normalized.endswith(ASSET_EXTENSIONS):
-                continue
-
-            links.add(normalized)
-    return sorted(links)
 
 
 @allure.feature("Links")
 @allure.severity("Critical")
 @allure.story("Crawler внутренних ссылок: HTTP + canonical + final URL")
 def test_internal_links_crawler_http_and_canonical(driver):
-    links = _collect_internal_links(driver)
-    assert links, "Crawler не собрал ни одной внутренней ссылки"
-
-    bad_links = []
-
-    for link in links:
-        # 1) Проверяем, что ссылка не уходит в 4xx/5xx сразу.
-        first = requests.get(link, timeout=20, allow_redirects=False)
-        if first.status_code >= 400:
-            bad_links.append(f"{link} -> first_status={first.status_code}")
-            continue
-
-        # 2) Проверяем финальный переход (с учетом редиректов).
-        final = requests.get(link, timeout=20, allow_redirects=True)
-        if final.status_code >= 400:
-            bad_links.append(f"{link} -> final_status={final.status_code}")
-            continue
-
-        final_url = _normalize_url(final.url)
-
-        # 3) Проверяем canonical на HTML страницах.
-        content_type = (final.headers.get("Content-Type") or "").lower()
-        if "text/html" in content_type:
-            canonical_href = _extract_canonical_href(final.text or "")
-            if canonical_href:
-                canonical_abs = urljoin(final.url, canonical_href)
-                canonical_url = _normalize_url(canonical_abs)
-                if canonical_url != final_url:
-                    bad_links.append(
-                        f"{link} -> canonical_mismatch: canonical={canonical_url} final={final_url}"
-                    )
-
-    assert not bad_links, "Обнаружены проблемы внутренних ссылок:\n" + "\n".join(bad_links[:40])
+    page = InternalLinksCrawlerPage(driver)
+    page.check_internal_links_http_and_canonical()

--- a/test_new_web_site/test_main_page.py
+++ b/test_new_web_site/test_main_page.py
@@ -46,13 +46,8 @@ def test_subscription_cards_texts_and_links(driver):
     page.open()
     page.accept_cookie_consent()
 
-    # Проверяем обычные карточки
-    page._check_subscription_cards(in_archive=False)
-
-    # Проверяем архивные карточки
-    page.open_archive_modal()
-    page._check_subscription_cards(in_archive=True)
-    page.close_archive_modal()
+    page.check_regular_subscription_cards()
+    page.check_archive_subscription_cards()
 
 
 @allure.feature("Main Page")
@@ -66,7 +61,7 @@ def test_subscription_links_regular_cards(driver):
     page = MainPage(driver)
     page.open()
     page.accept_cookie_consent()
-    page._check_subscription_cards(in_archive=False)
+    page.check_regular_subscription_cards()
 
 
 @allure.feature("Main Page")
@@ -81,14 +76,7 @@ def test_subscription_links_archive_cards(driver):
     page.open()
     page.accept_cookie_consent()
 
-    # Открываем модалку архивных подписок
-    page.open_archive_modal()
-
-    # Проверяем переходы по ссылкам
-    page._check_subscription_cards(in_archive=True)
-
-    # Закрываем модалку
-    page.close_archive_modal()
+    page.check_archive_subscription_cards()
 
 
 @allure.feature("Main Page")
@@ -119,13 +107,8 @@ def test_subscription_facilities_tables_load(driver):
     page.open()
     page.accept_cookie_consent()
 
-    # Проверяем таблицы обычных карточек
-    page._check_subscription_cards(in_archive=False)
-
-    # Проверяем таблицы архивных карточек
-    page.open_archive_modal()
-    page._check_subscription_cards(in_archive=True)
-    page.close_archive_modal()
+    page.check_regular_subscription_cards()
+    page.check_archive_subscription_cards()
 
 
 @allure.feature("Main Page")
@@ -141,13 +124,8 @@ def test_subscription_card_texts_valid(driver):
     page.open()
     page.accept_cookie_consent()
 
-    # Проверяем тексты карточек обычных подписок
-    page._check_subscription_cards(in_archive=False)
-
-    # Проверяем тексты карточек архивных подписок
-    page.open_archive_modal()
-    page._check_subscription_cards(in_archive=True)
-    page.close_archive_modal()
+    page.check_regular_subscription_cards()
+    page.check_archive_subscription_cards()
 
     # ===================== TRUST / FEEDBACK SECTION ====================================================================================
 


### PR DESCRIPTION
## Summary
- move test_new_web_site health and internal-link checks behind page objects
- replace private page method calls in main and companies tests with public page APIs
- route app HTTP status checks through the AppPage object

## Verification
- python3 -m py_compile on updated page/test files
- /Users/olega/myproject/venv/bin/pytest test_new_web_site/test_main_page.py test_new_web_site/test_companies_page.py test_new_web_site/test_app_page.py test_new_web_site/test_endpoints_and_console.py test_new_web_site/test_internal_links_crawler.py --collect-only -q