### PR TITLE
Add exact contacts block assertions

### DIFF
--- a/pages/new_web_site/companies.py
+++ b/pages/new_web_site/companies.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import re
 import time
 import allure
 from selenium.webdriver.common.by import By
@@ -881,14 +882,34 @@ class CompaniesPage(BasePage):
 
     @allure.step("Проверить корректность контактных данных")
     def check_contacts_data(self):
-        """Проверяет наличие ключевых контактных данных в блоке."""
+        """Проверяет точное совпадение текста в блоке 'Наши контакты'."""
         self._safe_scroll(L.CONTACTS_SECTION)
         root = self.driver.find_element(*L.CONTACTS_SECTION)
-        phones = root.find_elements(By.CSS_SELECTOR, "a[href^='tel:']")
-        emails = root.find_elements(By.CSS_SELECTOR, "a[href^='mailto:']")
-        assert len(phones) >= 2, f"Недостаточно телефонных ссылок в контактах: {len(phones)}"
-        assert len(emails) >= 2, f"Недостаточно email-ссылок в контактах: {len(emails)}"
-        assert "минск" in root.text.lower(), "В блоке контактов не найден адрес (Минск)"
+        actual_text = re.sub(r"\s+", " ", root.text.replace("\xa0", " ")).strip()
+
+        expected_fragments = [
+            "Наши контакты",
+            "Отдел по работе с клиентами",
+            "+375 44 771 09 47",
+            "sales@allsports.by",
+            "(пн-пт: 09:00-18:00, сб-вс: выходной)",
+            "Отдел по работе с партнёрами",
+            "+375 44 525 38 92",
+            "suppliers@allsports.by",
+            "(пн-пт: 09:00-18:00, сб-вс: выходной)",
+            "Техническая поддержка",
+            "+375 44 770 94 26",
+            "support@allsports.by",
+            "(пн-пт: 9:00-21:00, сб-вс: 9:00-19:00)",
+            "Адрес:",
+            "220030 г. Минск, ул. Интернациональная, 36-2, офисы 2-20, 1-21",
+        ]
+
+        for fragment in expected_fragments:
+            assert fragment in actual_text, (
+                f"В блоке 'Наши контакты' не найден ожидаемый текст: {fragment}\n"
+                f"Фактический текст блока: {actual_text}"
+            )
 
     @allure.step("Проверить, что карта отображается и не сломана")
     def check_contacts_map(self):
@@ -1292,6 +1313,4 @@ class CompaniesPage(BasePage):
             EC.invisibility_of_element_located(L.SUBSCRIPTIONS_ARCHIVE_MODAL)
         )
         time.sleep(0.6)
-
-
 

--- a/pages/new_web_site/contacts.py
+++ b/pages/new_web_site/contacts.py
@@ -87,28 +87,36 @@ class ContactsPage(BasePage, ContactsPageLocators):
     @allure.step("Проверить, что контактные данные совпадают с ожидаемыми")
     def check_contacts_text_exact(self):
         """
-        Проверяет, что телефоны, e-mail и адрес на странице совпадают с эталонными.
-        Использует явное сравнение текста, как на макете.
+        Проверяет, что весь текст блока контактов совпадает с эталонными данными,
+        включая телефоны, e-mail, время работы и адрес.
         """
+        self._safe_scroll(self.ADDRESS_BLOCK)
+        root = self.driver.find_element(By.XPATH, self.ADDRESS_BLOCK)
+        actual_text = re.sub(r"\s+", " ", root.text.replace("\xa0", " ")).strip()
 
-        # --- Эталонные данные (из твоего скриншота) ---
-        expected_contacts = {
-            "clients_phone": "+375 44 771 09 47",
-            "clients_email": "sales@allsports.by",
-            "partners_phone": "+375 44 525 38 92",
-            "partners_email": "suppliers@allsports.by",
-            "support_phone": "+375 44 770 94 26",
-            "support_email": "support@allsports.by",
-            "address": "220030 г. Минск, ул. Интернациональная, 36-2, офисы 2-20, 1-21",
-        }
+        expected_fragments = [
+            "Наши контакты",
+            "Отдел по работе с клиентами",
+            "+375 44 771 09 47",
+            "sales@allsports.by",
+            "(пн-пт: 09:00-18:00, сб-вс: выходной)",
+            "Отдел по работе с партнёрами",
+            "+375 44 525 38 92",
+            "suppliers@allsports.by",
+            "(пн-пт: 09:00-18:00, сб-вс: выходной)",
+            "Техническая поддержка",
+            "+375 44 770 94 26",
+            "support@allsports.by",
+            "(пн-пт: 9:00-21:00, сб-вс: 9:00-19:00)",
+            "Адрес:",
+            "220030 г. Минск, ул. Интернациональная, 36-2, офисы 2-20, 1-21",
+        ]
 
-        # --- Проверка телефонов ---
-        page_source = self.driver.page_source
-
-        for key, value in expected_contacts.items():
-            assert value in page_source, f"❌ Текст '{value}' не найден на странице (ключ: {key})"
-
-        print("✅ Все контактные данные успешно найдены на странице.")
+        for fragment in expected_fragments:
+            assert fragment in actual_text, (
+                f"❌ В блоке контактов не найден ожидаемый текст: {fragment}\n"
+                f"Фактический текст блока: {actual_text}"
+            )
 
 
     # ==== Вспомогательные заполнители ====

--- a/pages/new_web_site/main_page.py
+++ b/pages/new_web_site/main_page.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import re
 import time
 import allure
 from selenium.common.exceptions import NoSuchElementException, TimeoutException, WebDriverException
@@ -613,14 +614,34 @@ class MainPage(BasePage):
 
     @allure.step("Проверить корректность контактных данных")
     def check_contacts_data(self):
-        """Проверяет наличие ключевых контактных данных в блоке."""
+        """Проверяет точное совпадение текста в блоке 'Наши контакты'."""
         self._safe_scroll(L.CONTACTS_SECTION)
         root = self.driver.find_element(*L.CONTACTS_SECTION)
-        phones = root.find_elements(By.CSS_SELECTOR, "a[href^='tel:']")
-        emails = root.find_elements(By.CSS_SELECTOR, "a[href^='mailto:']")
-        assert len(phones) >= 2, f"Недостаточно телефонных ссылок: {len(phones)}"
-        assert len(emails) >= 2, f"Недостаточно email-ссылок: {len(emails)}"
-        assert "минск" in root.text.lower(), "Адрес в блоке контактов не найден"
+        actual_text = re.sub(r"\s+", " ", root.text.replace("\xa0", " ")).strip()
+
+        expected_fragments = [
+            "Наши контакты",
+            "Отдел по работе с клиентами",
+            "+375 44 771 09 47",
+            "sales@allsports.by",
+            "(пн-пт: 09:00-18:00, сб-вс: выходной)",
+            "Отдел по работе с партнёрами",
+            "+375 44 525 38 92",
+            "suppliers@allsports.by",
+            "(пн-пт: 09:00-18:00, сб-вс: выходной)",
+            "Техническая поддержка",
+            "+375 44 770 94 26",
+            "support@allsports.by",
+            "(пн-пт: 9:00-21:00, сб-вс: 9:00-19:00)",
+            "Адрес:",
+            "220030 г. Минск, ул. Интернациональная, 36-2, офисы 2-20, 1-21",
+        ]
+
+        for fragment in expected_fragments:
+            assert fragment in actual_text, (
+                f"В блоке 'Наши контакты' не найден ожидаемый текст: {fragment}\n"
+                f"Фактический текст блока: {actual_text}"
+            )
 
     @allure.step("Проверить, что карта отображается и не сломана")
     def check_contacts_map(self):

--- a/pages/new_web_site/partners.py
+++ b/pages/new_web_site/partners.py
@@ -387,6 +387,36 @@ class PartnersPage(BasePage):
         self._safe_scroll((By.CSS_SELECTOR, "#contactsSection"))
         self.assert_element_present(L.CONTACTS_ADDRESS)
 
+    @allure.step("Проверить точное совпадение текста блока 'Наши контакты'")
+    def check_contacts_text_exact(self):
+        self._safe_scroll((By.CSS_SELECTOR, "#contactsSection"))
+        root = self.driver.find_element(*L.CONTACTS_SECTION)
+        actual_text = re.sub(r"\s+", " ", root.text.replace("\xa0", " ")).strip()
+
+        expected_fragments = [
+            "Наши контакты",
+            "Отдел по работе с клиентами",
+            "+375 44 771 09 47",
+            "sales@allsports.by",
+            "(пн-пт: 09:00-18:00, сб-вс: выходной)",
+            "Отдел по работе с партнёрами",
+            "+375 44 525 38 92",
+            "suppliers@allsports.by",
+            "(пн-пт: 09:00-18:00, сб-вс: выходной)",
+            "Техническая поддержка",
+            "+375 44 770 94 26",
+            "support@allsports.by",
+            "(пн-пт: 9:00-21:00, сб-вс: 9:00-19:00)",
+            "Адрес:",
+            "220030 г. Минск, ул. Интернациональная, 36-2, офисы 2-20, 1-21",
+        ]
+
+        for fragment in expected_fragments:
+            assert fragment in actual_text, (
+                f"В блоке 'Наши контакты' не найден ожидаемый текст: {fragment}\n"
+                f"Фактический текст блока: {actual_text}"
+            )
+
     @allure.step("Проверить наличие карты на странице")
     def check_contacts_map(self):
         self._safe_scroll((By.CSS_SELECTOR, "#contactsSection"))

--- a/test_new_web_site/test_companies_page.py
+++ b/test_new_web_site/test_companies_page.py
@@ -323,9 +323,9 @@ def test_contacts_section_present(driver):
 
 @allure.feature('Companies Page')
 @allure.severity('High')
-@allure.story('Контакты — корректность данных')
+@allure.story('Контакты — точное совпадение всех данных блока')
 def test_contacts_data(driver):
-    "Проверка корректности номеров телефонов, email и расписаний."
+    "Проверка полного текста блока контактов: телефоны, email, время работы и адрес."
     page = CompaniesPage(driver)
     page.open()
     page.accept_cookie_consent()

--- a/test_new_web_site/test_main_page.py
+++ b/test_new_web_site/test_main_page.py
@@ -275,9 +275,9 @@ def test_contacts_section_present(driver):
 
 @allure.feature('Main Page')
 @allure.severity('High')
-@allure.story('Контакты — корректность данных')
+@allure.story('Контакты — точное совпадение всех данных блока')
 def test_contacts_data(driver):
-    "Проверка корректности номеров телефонов, email и расписаний."
+    "Проверка полного текста блока контактов: телефоны, email, время работы и адрес."
     page = MainPage(driver)
     page.open()
     page.accept_cookie_consent()

--- a/test_new_web_site/test_partners_page.py
+++ b/test_new_web_site/test_partners_page.py
@@ -285,6 +285,16 @@ def test_contacts_address(driver):
     page.check_contacts_address()
 
 @allure.feature('Partners Page')
+@allure.severity('High')
+@allure.story('Контакты — точное совпадение всех данных блока')
+def test_contacts_text_exact(driver):
+    "Проверка полного текста блока контактов: телефоны, email, время работы и адрес."
+    page = PartnersPage(driver)
+    page.open()
+    page.accept_cookie_consent()
+    page.check_contacts_text_exact()
+
+@allure.feature('Partners Page')
 @allure.severity('Normal')
 @allure.story('Контакты — карта')
 def test_contacts_map(driver):
@@ -323,7 +333,6 @@ def test_contacts_responsive(driver):
     page.open()
     page.accept_cookie_consent()
     page.check_contacts_responsive()
-
 
 
 


### PR DESCRIPTION
## Summary
- add exact text assertions for the contacts block on main, companies, partners, and contacts pages
- align expected contact labels and working hours with the current site text
- keep coverage focused on the current visible contact data